### PR TITLE
Recognise top-level JSON-LD in Operation.process_json

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "web-algebra"
-version = "1.2.0"
+version = "1.3.0"
 description = "Composable RDF operations in JSON"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/web_algebra/operation.py
+++ b/src/web_algebra/operation.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+import json
 import logging
 from typing import Type, Dict, Optional, Any, List, ClassVar, Union
 from pydantic import BaseModel, Field, ConfigDict
@@ -7,6 +8,13 @@ from rdflib.term import Node
 from rdflib import URIRef, Literal, BNode, Graph
 from rdflib.namespace import XSD
 from rdflib.query import Result
+
+
+# JSON-LD keyword set used to recognise a top-level dict as RDF data rather
+# than generic JSON to recurse into. Presence of any of these at the root is
+# a strong, unambiguous signal — they are JSON-LD reserved terms with no
+# legitimate meaning in non-RDF JSON.
+_JSONLD_KEYS = ("@context", "@graph", "@id", "@type")
 
 
 class Operation(ABC, BaseModel):
@@ -91,7 +99,24 @@ class Operation(ABC, BaseModel):
                 # Return RDFLib objects as-is for operation chaining
                 return result
 
-            # 🔁 Recurse into each value — allows nested @op inside JSON-LD and SPARQL bindings
+            # JSON-LD shape recognition — a dict carrying any JSON-LD reserved
+            # key is RDF data, not generic JSON to recurse into. Parse it
+            # once at the runtime layer so every consuming op (POST, PUT,
+            # Merge, ldh-Create*/Add*) receives an `rdflib.Graph` directly
+            # instead of re-parsing identically inside its own
+            # `execute_json`. Symmetric with the bare-value auto-wrap
+            # below: that branch turns a JSON scalar into the matching
+            # RDFLib term; this branch turns a JSON-LD object into the
+            # matching RDFLib graph.
+            if any(k in json_data for k in _JSONLD_KEYS):
+                graph = Graph()
+                graph.parse(data=json.dumps(json_data), format="json-ld")
+                return graph
+
+            # 🔁 Recurse into each value — allows nested @op inside generic
+            # JSON structures (e.g. SPARQL binding objects), without
+            # collapsing pure-data dicts that JSON-LD detection above
+            # already handled.
             return {
                 k: cls.process_json(settings, v, context, variable_stack)
                 for k, v in json_data.items()


### PR DESCRIPTION
## Summary
- `Operation.process_json` now parses a top-level dict carrying any JSON-LD reserved key (`@context`, `@graph`, `@id`, `@type`) into an `rdflib.Graph`, ahead of the existing generic-dict recursion. Symmetric with the bare-value auto-wrap (`json_to_rdflib`): a JSON scalar becomes a `Literal`; a JSON-LD object becomes a `Graph`.
- Previously every consuming op (`POST`, `PUT`, `Merge`, `ldh-CreateItem`, `ldh-CreateContainer`, the `ldh-Add*` family) re-parsed the same JSON-LD payload in its own `execute_json`. The runtime treated bare JSON-LD as opaque JSON to recurse into; only the ops at the boundary knew its semantics.
- Unblocks the chat-extraction use case in AutoGraph: an LLM that emits JSON-LD as its final answer (image-extracted structured metadata) now gets a real Graph result the renderer can lay out — instead of a dict of Literals that renders as raw text.
- Version bumped to 1.3.0.

## Test plan
- [x] Existing unit suite — `uv run pytest tests/unit -q` → 96 passed, 0 failed.
- [x] Smoke trace — a bare JSON-LD dict (`@context` + `@graph` describing a `schema:Car`) handed to `Operation.process_json` now returns an `rdflib.Graph` with the expected triple count, instead of a dict.
- [ ] Once tagged and consumed by AutoGraph, end-to-end chat verification: an LLM emitting structured JSON-LD as its final answer renders as a structured per-subject view via `render_graph`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)