### PR TITLE
Prefix Generate* LDH ops with ldh-

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,21 +49,34 @@ The operations cover read-write Linked Data, SPARQL queries, URI manipulation, a
   - `DESCRIBE`
   - `SELECT`
   - `Substitute`
+  - `SPARQLString`
+- Schema
+  - `ExtractClasses`
+  - `ExtractDatatypeProperties`
+  - `ExtractObjectProperties`
+  - `ExtractOntology`
 - URI & String Operations
   - `ResolveURI`
   - `EncodeForURI`
   - `Concat`
   - `Replace`
   - `Str`
+  - `STRUUID`
   - `URI`
 - Control Flow & Variables
   - `Value`
   - `Variable`
   - `ForEach`
+  - `Filter`
+  - `Bindings`
+  - `Current`
+  - `Execute`
+  - `Merge`
 - LinkedDataHub-specific
   - `ldh-CreateContainer`
   - `ldh-CreateItem`
   - `ldh-List`
+  - `ldh-AddFile`
   - `ldh-AddGenericService`
   - `ldh-AddResultSetChart`
   - `ldh-AddSelect`
@@ -71,6 +84,9 @@ The operations cover read-write Linked Data, SPARQL queries, URI manipulation, a
   - `ldh-AddObjectBlock`
   - `ldh-AddXHTMLBlock`
   - `ldh-RemoveBlock`
+  - `ldh-GeneratePortal`
+  - `ldh-GenerateClassContainers`
+  - `ldh-GenerateOntologyViews`
 
 ## Usage
 

--- a/examples/generate-portal.json
+++ b/examples/generate-portal.json
@@ -1,5 +1,5 @@
 {
-  "@op": "GeneratePortal",
+  "@op": "ldh-GeneratePortal",
   "args": {
     "endpoint": {
       "@op": "URI",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "web-algebra"
-version = "1.3.1"
+version = "1.4.0"
 description = "Composable RDF operations in JSON"
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "web-algebra"
-version = "1.3.0"
+version = "1.3.1"
 description = "Composable RDF operations in JSON"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/web_algebra/operations/linkeddatahub/content/generate_class_containers.py
+++ b/src/web_algebra/operations/linkeddatahub/content/generate_class_containers.py
@@ -21,6 +21,10 @@ class GenerateClassContainers(Operation):
     """
 
     @classmethod
+    def name(cls):
+        return "ldh-GenerateClassContainers"
+
+    @classmethod
     def description(cls) -> str:
         return "Creates LinkedDataHub containers with instance list views for ontology classes"
 

--- a/src/web_algebra/operations/linkeddatahub/content/generate_ontology_views.py
+++ b/src/web_algebra/operations/linkeddatahub/content/generate_ontology_views.py
@@ -16,6 +16,10 @@ class GenerateOntologyViews(Operation):
     """
 
     @classmethod
+    def name(cls):
+        return "ldh-GenerateOntologyViews"
+
+    @classmethod
     def description(cls) -> str:
         return "Generates LinkedDataHub view templates and SPIN queries for non-functional properties"
 

--- a/src/web_algebra/operations/linkeddatahub/content/generate_portal.py
+++ b/src/web_algebra/operations/linkeddatahub/content/generate_portal.py
@@ -21,6 +21,10 @@ class GeneratePortal(Operation):
     """
 
     @classmethod
+    def name(cls):
+        return "ldh-GeneratePortal"
+
+    @classmethod
     def description(cls) -> str:
         return "Generates a complete LinkedDataHub portal with class containers and property views from a SPARQL endpoint"
 

--- a/uv.lock
+++ b/uv.lock
@@ -888,7 +888,7 @@ wheels = [
 
 [[package]]
 name = "web-algebra"
-version = "1.3.1"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },

--- a/uv.lock
+++ b/uv.lock
@@ -888,7 +888,7 @@ wheels = [
 
 [[package]]
 name = "web-algebra"
-version = "1.2.0"
+version = "1.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary
- Add `name()` overrides to `GeneratePortal`, `GenerateClassContainers`, and `GenerateOntologyViews` so they register as `ldh-GeneratePortal`, `ldh-GenerateClassContainers`, and `ldh-GenerateOntologyViews` — matching the convention used by every other op under `linkeddatahub/`.
- Update `examples/generate-portal.json` to use the new name.
- Refresh the README operation list: add the prefixed `Generate*` ops plus a number of previously undocumented ones (Schema category, `SPARQLString`, `STRUUID`, `Filter`, `Bindings`, `Current`, `Execute`, `Merge`, `ldh-AddFile`).
- Bump patch version to 1.3.1.

This is a breaking change for any external workflow JSON that references the bare `Generate*` names, but those were the only LDH ops missing the prefix and no other examples/tests use them.

## Test plan
- [x] `uv run pytest tests/` — 106 passed, 44 skipped (same as before)
- [x] Confirmed `name()` returns prefixed strings via direct import
- [ ] Manual smoke test of `examples/generate-portal.json` against a running LDH instance